### PR TITLE
Pass B2 env vars to docker container

### DIFF
--- a/bin/linux/bdde
+++ b/bin/linux/bdde
@@ -41,5 +41,5 @@ else
   set -x
   docker run --rm --cap-add=SYS_PTRACE --security-opt seccomp=unconfined ${BDDE_DOCK} \
     -v "${BOOST_ROOT}:/boost:rw" -v "${BDDE_ROOT}:/bdde:ro" -v "${HOME}/.vimrc:/home/boost/.vimrc:ro" \
-      --user $(id -u):$(id -g) --workdir "${BOOST_STEM}" ${IT} "${env_vars[@]} ${BDDE_REPO}:${BDDE_SLUG} ${BDDE_SHELL}
+      --user $(id -u):$(id -g) --workdir "${BOOST_STEM}" ${IT} "${env_vars[@]}" ${BDDE_REPO}:${BDDE_SLUG} ${BDDE_SHELL}
 fi

--- a/bin/linux/bdde
+++ b/bin/linux/bdde
@@ -26,14 +26,20 @@ else
   IT=-i
 fi
 
+# Export all env vars starting with B2
+env_vars=()
+for var in "${!B2@}"; do
+  env_vars+=(-e "$var")
+done
+
 if [ $# -ne 0 ]; then
   set -x
   docker run --rm --cap-add=SYS_PTRACE --security-opt seccomp=unconfined ${BDDE_DOCK} \
     -v "${BOOST_ROOT}:/boost:rw" -v "${BDDE_ROOT}:/bdde:ro" -v "${HOME}/.vimrc:/home/boost/.vimrc:ro" \
-    --user $(id -u):$(id -g) --workdir "${BOOST_STEM}" ${IT} ${BDDE_REPO}:${BDDE_SLUG} ${BDDE_SHELL} -c "$*"
+    --user $(id -u):$(id -g) --workdir "${BOOST_STEM}" ${IT} "${env_vars[@]}" ${BDDE_REPO}:${BDDE_SLUG} ${BDDE_SHELL} -c "$*"
 else
   set -x
   docker run --rm --cap-add=SYS_PTRACE --security-opt seccomp=unconfined ${BDDE_DOCK} \
     -v "${BOOST_ROOT}:/boost:rw" -v "${BDDE_ROOT}:/bdde:ro" -v "${HOME}/.vimrc:/home/boost/.vimrc:ro" \
-      --user $(id -u):$(id -g) --workdir "${BOOST_STEM}" ${IT} ${BDDE_REPO}:${BDDE_SLUG} ${BDDE_SHELL}
+      --user $(id -u):$(id -g) --workdir "${BOOST_STEM}" ${IT} "${env_vars[@]} ${BDDE_REPO}:${BDDE_SLUG} ${BDDE_SHELL}
 fi


### PR DESCRIPTION
Without this variables such as B2_DONT_EMBED_MANIFEST get ignored and it gets impossible to e.g. even build B2. See https://github.com/boostorg/boost-ci/pull/227

See https://github.com/boostorg/boost-ci/actions/runs/7799491253/job/21270553772?pr=227 for a job using this change