### PR TITLE
Pass through $B2_DONT_EMBED_MANIFEST

### DIFF
--- a/bin/linux/bdde
+++ b/bin/linux/bdde
@@ -28,12 +28,12 @@ fi
 
 if [ $# -ne 0 ]; then
   set -x
-  docker run --rm --cap-add=SYS_PTRACE --security-opt seccomp=unconfined ${BDDE_DOCK} \
+  docker run --rm --cap-add=SYS_PTRACE --security-opt seccomp=unconfined ${BDDE_DOCK} -e B2_DONT_EMBED_MANIFEST \
     -v "${BOOST_ROOT}:/boost:rw" -v "${BDDE_ROOT}:/bdde:ro" -v "${HOME}/.vimrc:/home/boost/.vimrc:ro" \
     --user $(id -u):$(id -g) --workdir "${BOOST_STEM}" ${IT} ${BDDE_REPO}:${BDDE_SLUG} ${BDDE_SHELL} -c "$*"
 else
   set -x
-  docker run --rm --cap-add=SYS_PTRACE --security-opt seccomp=unconfined ${BDDE_DOCK} \
+  docker run --rm --cap-add=SYS_PTRACE --security-opt seccomp=unconfined ${BDDE_DOCK} -e B2_DONT_EMBED_MANIFEST  \
     -v "${BOOST_ROOT}:/boost:rw" -v "${BDDE_ROOT}:/bdde:ro" -v "${HOME}/.vimrc:/home/boost/.vimrc:ro" \
       --user $(id -u):$(id -g) --workdir "${BOOST_STEM}" ${IT} ${BDDE_REPO}:${BDDE_SLUG} ${BDDE_SHELL}
 fi


### PR DESCRIPTION
This is required or the bootstrap of b2 will fail with:

> windres --input res.rc --output res.o
> /usr/bin/windres: Can't detect architecture.

Minimal version of #4